### PR TITLE
FEATURE: UX improvements to leaderboard page

### DIFF
--- a/.env.SAMPLE
+++ b/.env.SAMPLE
@@ -1,0 +1,3 @@
+GOOGLE_CLIENT_ID=see-instructions-in-readme
+GOOGLE_CLIENT_SECRET=see-instructions-in-readme
+ADMIN_EMAILS=phtcon@ucsb.edu

--- a/.env.SAMPLE
+++ b/.env.SAMPLE
@@ -1,3 +1,0 @@
-GOOGLE_CLIENT_ID=see-instructions-in-readme
-GOOGLE_CLIENT_SECRET=see-instructions-in-readme
-ADMIN_EMAILS=phtcon@ucsb.edu

--- a/frontend/src/main/components/Leaderboard/LeaderboardTable.js
+++ b/frontend/src/main/components/Leaderboard/LeaderboardTable.js
@@ -68,8 +68,6 @@ export default function LeaderboardTable({ leaderboardUsers }) {
 
     const testid = "LeaderboardTable";
 
-    /* Temp filler for admin leaderboard table */
-
 
     return <OurTable
         data={leaderboardUsers}

--- a/frontend/src/main/components/Leaderboard/LeaderboardTable.js
+++ b/frontend/src/main/components/Leaderboard/LeaderboardTable.js
@@ -1,8 +1,7 @@
 import OurTable from "main/components/OurTable";
-import { hasRole } from "main/utils/currentUser";
 
 // should take in a players list from a commons
-export default function LeaderboardTable({ leaderboardUsers , currentUser }) {
+export default function LeaderboardTable({ leaderboardUsers }) {
 
     const USD = new Intl.NumberFormat("en-US", {
         style: "currency",
@@ -11,11 +10,7 @@ export default function LeaderboardTable({ leaderboardUsers , currentUser }) {
 
     const columns = [
         {
-            Header: 'User Id',
-            accessor: 'userId', 
-        },
-        {
-            Header: 'Username',
+            Header: 'Farmer',
             accessor: 'username', 
         },
         {
@@ -32,22 +27,42 @@ export default function LeaderboardTable({ leaderboardUsers , currentUser }) {
         {
             Header: 'Cows Owned',
             accessor: 'numOfCows', 
+            Cell: (props) => {
+                return (
+                  <div style={{textAlign: "right"}}>{props.value}</div>)
+                  },
         },
         {
             Header: 'Cow Health',
             accessor: 'cowHealth', 
+            Cell: (props) => {
+                return (
+                  <div style={{textAlign: "right"}}>{props.value}</div>)
+                  },
         },
         {
             Header: 'Cows Bought',
             accessor: 'cowsBought', 
+            Cell: (props) => {
+                return (
+                  <div style={{textAlign: "right"}}>{props.value}</div>)
+                  },
         },
         {
             Header: 'Cows Sold',
             accessor: 'cowsSold', 
+            Cell: (props) => {
+                return (
+                  <div style={{textAlign: "right"}}>{props.value}</div>)
+                  },
         },
         {
             Header: 'Cow Deaths',
             accessor: 'cowDeaths', 
+            Cell: (props) => {
+                return (
+                  <div style={{textAlign: "right"}}>{props.value}</div>)
+                  },
         },
     ];
 
@@ -55,20 +70,10 @@ export default function LeaderboardTable({ leaderboardUsers , currentUser }) {
 
     /* Temp filler for admin leaderboard table */
 
-    const columnsIfAdmin = [
-        {
-            Header: '(Admin) userCommons Id',
-            accessor: 'id'
-        },
-        ...columns
-
-    ];
-
-    const columnsToDisplay = hasRole(currentUser, "ROLE_ADMIN") ? columnsIfAdmin : columns;
 
     return <OurTable
         data={leaderboardUsers}
-        columns={columnsToDisplay}
+        columns={columns}
         testid={testid}
     />;
 

--- a/frontend/src/main/pages/LeaderboardPage.js
+++ b/frontend/src/main/pages/LeaderboardPage.js
@@ -61,7 +61,7 @@ export default function LeaderboardPage() {
           <h1>Leaderboard</h1>
           {
             showLeaderboard ?
-              (<LeaderboardTable leaderboardUsers={userCommons} currentUser={currentUser} />) :
+              (<LeaderboardTable leaderboardUsers={userCommons} />) :
               (<p>You're not authorized to see the leaderboard.</p>)
           }
         </div>

--- a/frontend/src/main/pages/LeaderboardPage.js
+++ b/frontend/src/main/pages/LeaderboardPage.js
@@ -50,22 +50,22 @@ export default function LeaderboardPage() {
 
   const navigate = useNavigate();
 
-  const showLeaderboard = (hasRole(currentUser, "ROLE_ADMIN") || commons.showLeaderboard );
+  const showLeaderboard = (hasRole(currentUser, "ROLE_ADMIN") || commons.showLeaderboard);
   return (
-    <div data-testid={"LeaderboardPage-main-div"} style={{backgroundSize: 'cover', backgroundImage: `url(${Background})`}}>
-        <BasicLayout>
-            <div className="pt-2">
-                <h1>Leaderboard</h1>
-                {
-                  showLeaderboard?
-                  (<LeaderboardTable leaderboardUsers={userCommons} currentUser={currentUser} />) :
-                  (<p>You're not authorized to see the leaderboard.</p>)
-                }
-                </div>
-                <Button onClick={() => navigate(-1)} data-testid="LeaderboardPage-back-button" >
-                    Back
-                </Button>
-        </BasicLayout>
+    <div data-testid={"LeaderboardPage-main-div"} style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})` }}>
+      <BasicLayout>
+        <div className="pt-2">
+          <Button onClick={() => navigate(-1)} data-testid="LeaderboardPage-back-button" style={{ float: "right" }} >
+            Back
+          </Button>
+          <h1>Leaderboard</h1>
+          {
+            showLeaderboard ?
+              (<LeaderboardTable leaderboardUsers={userCommons} currentUser={currentUser} />) :
+              (<p>You're not authorized to see the leaderboard.</p>)
+          }
+        </div>
+      </BasicLayout>
     </div>
   )
 }

--- a/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
+++ b/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
@@ -105,6 +105,12 @@ describe("LeaderboardTable tests", () => {
     );
 
     expect(screen.getAllByText("$1,000.00")[0]).toHaveStyle("text-align: right;");
+    expect(screen.getAllByText("8")[0]).toHaveStyle("text-align: right;");
+    expect(screen.getAllByText("two")[0]).toHaveStyle("text-align: right;");
+    expect(screen.getAllByText("5")[0]).toHaveStyle("text-align: right;");
+
+
+
 
   });
     

--- a/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
+++ b/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
@@ -65,8 +65,8 @@ describe("LeaderboardTable tests", () => {
 
     );
 
-    const expectedHeaders = ['(Admin) userCommons Id', 'Username', 'User Id', 'Total Wealth', 'Cows Owned', 'Cow Health', 'Cows Bought', 'Cows Sold', 'Cow Deaths'];
-    const expectedFields = ['id', 'userId', 'username', 'totalWealth','numOfCows', 'cowHealth', 'cowsBought', 'cowsSold', 'cowDeaths'];
+    const expectedHeaders = ['Farmer', 'Total Wealth', 'Cows Owned', 'Cow Health', 'Cows Bought', 'Cows Sold', 'Cow Deaths'];
+    const expectedFields = ['username', 'totalWealth','numOfCows', 'cowHealth', 'cowsBought', 'cowsSold', 'cowDeaths'];
     const testId = "LeaderboardTable";
 
     expectedHeaders.forEach((headerText) => {
@@ -79,15 +79,11 @@ describe("LeaderboardTable tests", () => {
       expect(header).toBeInTheDocument();
     });
 
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-userId`)).toHaveTextContent("1");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-username`)).toHaveTextContent("one");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-totalWealth`)).toHaveTextContent("$1,000.00");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-cowsBought`)).toHaveTextContent("8");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-cowsSold`)).toHaveTextContent("8");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-cowDeaths`)).toHaveTextContent("8");
-    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
-    expect(screen.getByTestId(`${testId}-cell-row-1-col-userId`)).toHaveTextContent("2");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-username`)).toHaveTextContent("two");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-totalWealth`)).toHaveTextContent("$1,000.00");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-cowsBought`)).toHaveTextContent("5");

--- a/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
+++ b/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
@@ -92,22 +92,25 @@ describe("LeaderboardTable tests", () => {
 
   });
 
-  test("Total wealth is formatted correctly", () => {
+  test("All columns are formatted correctly", () => {
     const currentUser = currentUserFixtures.adminUser;
 
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <LeaderboardTable leaderboardUsers={leaderboardFixtures.threeUserCommonsLB} currentUser={currentUser} />
+          <LeaderboardTable leaderboardUsers={leaderboardFixtures.fiveUserCommonsLB} currentUser={currentUser} />
         </MemoryRouter>
       </QueryClientProvider>
 
     );
 
     expect(screen.getAllByText("$1,000.00")[0]).toHaveStyle("text-align: right;");
+    expect(screen.getAllByText("93")[0]).toHaveStyle("text-align: right;");
     expect(screen.getAllByText("8")[0]).toHaveStyle("text-align: right;");
-    expect(screen.getAllByText("two")[0]).toHaveStyle("text-align: right;");
-    expect(screen.getAllByText("5")[0]).toHaveStyle("text-align: right;");
+    expect(screen.getAllByText("8")[1]).toHaveStyle("text-align: right;");
+    expect(screen.getAllByText("8")[2]).toHaveStyle("text-align: right;");
+    expect(screen.getAllByText("8")[3]).toHaveStyle("text-align: right;");
+
 
 
 
@@ -116,4 +119,3 @@ describe("LeaderboardTable tests", () => {
     
 
 });
-

--- a/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
+++ b/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
@@ -2,7 +2,6 @@ import { render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import LeaderboardTable from "main/components/Leaderboard/LeaderboardTable";
-import { currentUserFixtures } from "fixtures/currentUserFixtures";
 import leaderboardFixtures from "fixtures/leaderboardFixtures";
 
 const mockedNavigate = jest.fn();
@@ -16,24 +15,22 @@ describe("LeaderboardTable tests", () => {
   const queryClient = new QueryClient();
 
   test("renders without crashing for empty table with user not logged in", () => {
-    const currentUser = null;
 
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <LeaderboardTable leaderboardUsers={[]} currentUser={currentUser} />
+          <LeaderboardTable leaderboardUsers={[]}/>
         </MemoryRouter>
       </QueryClientProvider>
 
     );
   });
   test("renders without crashing for empty table for ordinary user", () => {
-    const currentUser = currentUserFixtures.userOnly;
 
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <LeaderboardTable leaderboardUsers={[]} currentUser={currentUser} />
+          <LeaderboardTable leaderboardUsers={[]} />
         </MemoryRouter>
       </QueryClientProvider>
 
@@ -41,12 +38,11 @@ describe("LeaderboardTable tests", () => {
   });
 
   test("renders without crashing for empty table for admin", () => {
-    const currentUser = currentUserFixtures.adminUser;
 
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <LeaderboardTable leaderboardUsers={[]} currentUser={currentUser} />
+          <LeaderboardTable leaderboardUsers={[]} />
         </MemoryRouter>
       </QueryClientProvider>
 
@@ -54,12 +50,10 @@ describe("LeaderboardTable tests", () => {
   });
 
   test("Has the expected column headers and content for adminUser", () => {
-    const currentUser = currentUserFixtures.adminUser;
-
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <LeaderboardTable leaderboardUsers={leaderboardFixtures.threeUserCommonsLB} currentUser={currentUser} />
+          <LeaderboardTable leaderboardUsers={leaderboardFixtures.threeUserCommonsLB}/>
         </MemoryRouter>
       </QueryClientProvider>
 
@@ -93,12 +87,10 @@ describe("LeaderboardTable tests", () => {
   });
 
   test("All columns are formatted correctly", () => {
-    const currentUser = currentUserFixtures.adminUser;
-
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <LeaderboardTable leaderboardUsers={leaderboardFixtures.fiveUserCommonsLB} currentUser={currentUser} />
+          <LeaderboardTable leaderboardUsers={leaderboardFixtures.fiveUserCommonsLB} />
         </MemoryRouter>
       </QueryClientProvider>
 

--- a/frontend/src/tests/pages/LeaderboardPage.test.js
+++ b/frontend/src/tests/pages/LeaderboardPage.test.js
@@ -81,6 +81,7 @@ describe("LeaderboardPage tests", () => {
         const leaderboard_back_button = screen.getByTestId("LeaderboardPage-back-button");
         expect(leaderboard_main_div).toHaveAttribute("style","background-size: cover; background-image: url(PlayPageBackground.png);");
         expect(leaderboard_back_button).toBeInTheDocument();
+        expect(leaderboard_back_button).toHaveAttribute("style","float: right;")
     });
 
     test("that navigate(-1) is called when Back is clicked", async () => {


### PR DESCRIPTION
## Overview
In this PR, I moved the "back" button to the top of the page and made some leaderboard improvements like removing unnecessary columns.

## Screenshot
Before
<img width="489" alt="Screen Shot 2023-11-24 at 7 24 34 PM" src="https://github.com/ucsb-cs156-f23/proj-happycows-f23-5pm-3/assets/46539388/21684202-90f7-413e-b5cd-d31d1b6bf0d0">

After
<img width="1440" alt="Screen Shot 2023-11-24 at 7 21 12 PM" src="https://github.com/ucsb-cs156-f23/proj-happycows-f23-5pm-3/assets/46539388/e34efaeb-00b9-41c8-b1ce-e75a4c52eba3">

https://ucsb-cs156-f23.github.io/proj-happycows-f23-5pm-3/prs/20/storybook/?path=/story/components-leaderboard-leaderboardtable--five-user-commons

## Future Possibilities (Optional)
-  You can add the back button on top of the table rather than all the way to the right.

## Validation (Optional)
1. Download this branch.
2. Run the project.
3. Go to LeaderboardPage
4. Check columns and back button. 

## Tests
- [ ] Frontend Unit tests (`npm test`) pass
- [ ] Frontend Test coverage (`npm run coverage`) 100%
- [ ] Frontend Mutation tests (`npx stryker run`) 100% 
## Linked Issues
Closes #8 
