### PR TITLE
Madison - enforce game in progress for MilkTheCowsJob and InstructorReportJob

### DIFF
--- a/frontend/src/main/components/Jobs/UpdateCowHealthForm.js
+++ b/frontend/src/main/components/Jobs/UpdateCowHealthForm.js
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { useBackend } from "main/utils/useBackend";
 import CommonsSelect from "main/components/Commons/CommonsSelect";
+//import InstructorReportSpecificCommonsForm from "./InstructorReportSpecificCommonsForm";
 
 function UpdateCowHealthForm( { submitAction, testid = "UpdateCowHealthForm" } ) {
 

--- a/frontend/src/main/components/Jobs/UpdateCowHealthForm.js
+++ b/frontend/src/main/components/Jobs/UpdateCowHealthForm.js
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { useBackend } from "main/utils/useBackend";
 import CommonsSelect from "main/components/Commons/CommonsSelect";
-//import InstructorReportSpecificCommonsForm from "./InstructorReportSpecificCommonsForm";
+
 
 function UpdateCowHealthForm( { submitAction, testid = "UpdateCowHealthForm" } ) {
 

--- a/frontend/src/main/components/Jobs/UpdateCowHealthForm.js
+++ b/frontend/src/main/components/Jobs/UpdateCowHealthForm.js
@@ -4,9 +4,7 @@ import { useForm } from "react-hook-form";
 import { useBackend } from "main/utils/useBackend";
 import CommonsSelect from "main/components/Commons/CommonsSelect";
 
-
 function UpdateCowHealthForm( { submitAction, testid = "UpdateCowHealthForm" } ) {
-
   // Stryker restore all
 
   const { data: commonsAll } = useBackend(
@@ -16,12 +14,9 @@ function UpdateCowHealthForm( { submitAction, testid = "UpdateCowHealthForm" } )
   );
 
   const allCommonsProp = {"id":0,"name":"All Commons"}
-  
   const commons = [allCommonsProp, ...commonsAll]
-
   const [selectedCommons, setSelectedCommons] = useState(null);
   const [selectedCommonsName, setSelectedCommonsName] = useState(null);
-
   const {
     handleSubmit,
   } = useForm();

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
@@ -22,7 +22,6 @@ public class Commons {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
-
     private String name;
     private double cowPrice;
     private double milkPrice;
@@ -35,22 +34,17 @@ public class Commons {
     private int carryingCapacity;
     private double degradationRate;
     
-
     public boolean gameInProgress(){
         boolean output = (startingDate.isBefore(LocalDateTime.now()) && lastDay.isAfter(LocalDateTime.now()));
         return output;
       }
 
-
-
-        // these defaults match old behavior
     @Enumerated(EnumType.STRING)
     @Builder.Default
     private CowHealthUpdateStrategies belowCapacityHealthUpdateStrategy = CowHealthUpdateStrategies.DEFAULT_BELOW_CAPACITY;
     @Enumerated(EnumType.STRING)
     @Builder.Default
     private CowHealthUpdateStrategies aboveCapacityHealthUpdateStrategy = CowHealthUpdateStrategies.DEFAULT_ABOVE_CAPACITY;
-
 
     @OneToMany(mappedBy = "commons", cascade = CascadeType.REMOVE)
     @JsonIgnore

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
@@ -34,11 +34,14 @@ public class Commons {
     private int capacityPerUser;
     private int carryingCapacity;
     private double degradationRate;
+    
 
     public boolean gameInProgress(){
         boolean output = (startingDate.isBefore(LocalDateTime.now()) && lastDay.isAfter(LocalDateTime.now()));
         return output;
       }
+
+
 
         // these defaults match old behavior
     @Enumerated(EnumType.STRING)

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJob.java
@@ -24,10 +24,15 @@ public class InstructorReportJob implements JobContextConsumer {
         Iterable<Commons> allCommons = commonsRepository.findAll();
 
         for (Commons commons : allCommons) {
-            ctx.log(String.format("Starting Commons id=%d (%s)...", commons.getId(), commons.getName()));
-            Report report = reportService.createReport(commons.getId());
-            ctx.log(String.format("Report %d for commons id=%d (%s) finished.", report.getId(), commons.getId(),
-                    commons.getName()));
+            
+            if(commons.gameInProgress()){
+                ctx.log(String.format("Starting Commons id=%d (%s)...", commons.getId(), commons.getName()));
+                Report report = reportService.createReport(commons.getId());
+                ctx.log(String.format("Report %d for commons id=%d (%s) finished.", report.getId(), commons.getId(),
+                commons.getName()));
+            }else {
+                ctx.log("Game is not currently in progress, report will not be filed in this common.");
+            }       
         }
         ctx.log("Instructor report done!");
     }

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJob.java
@@ -39,13 +39,17 @@ public class MilkTheCowsJob implements JobContextConsumer {
 
         for (Commons commons : allCommons) {
             String name = commons.getName();
-            double milkPrice = commons.getMilkPrice();
-            ctx.log("Milking cows for Commons: " + name + ", Milk Price: " + formatDollars(milkPrice));
+            if(commons.gameInProgress()){
+                double milkPrice = commons.getMilkPrice();
+                ctx.log("Milking cows for Commons: " + name + ", Milk Price: " + formatDollars(milkPrice));
 
-            Iterable<UserCommons> allUserCommons = userCommonsRepository.findByCommonsId(commons.getId());
+                Iterable<UserCommons> allUserCommons = userCommonsRepository.findByCommonsId(commons.getId());
 
-            for (UserCommons userCommons : allUserCommons) {
-                milkCows(ctx, commons, userCommons, profitRepository, userCommonsRepository);
+                for (UserCommons userCommons : allUserCommons) {
+                    milkCows(ctx, commons, userCommons, profitRepository, userCommonsRepository);
+                }
+            } else {
+                ctx.log("Commons " + name + " is not currently in progress, cows will not be milked in this commons.");
             }
         }
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJob.java
@@ -39,7 +39,8 @@ public class MilkTheCowsJob implements JobContextConsumer {
 
         for (Commons commons : allCommons) {
             String name = commons.getName();
-            if(commons.gameInProgress()){
+            if(commons.gameInProgress()) {
+
                 double milkPrice = commons.getMilkPrice();
                 ctx.log("Milking cows for Commons: " + name + ", Milk Price: " + formatDollars(milkPrice));
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
@@ -38,12 +38,13 @@ public class UpdateCowHealthJob implements JobContextConsumer {
 
 
             Commons commons = commonsPlus.getCommons();
-            if(!commons.gameInProgress()){
-                ctx.log("Game is not currently in progress, cow health will not be updated for this commons.");
+            //ctx.log(String.format("commoms.startDate=%s commons.lastDay=%s", commons.getStartingDate().toString(),commons.getLastDay().toString()));
+            if(commons.gameInProgress()){
+                
+                runUpdateJobInCommons(commons, commonsPlus, commonsPlusBuilderService, commonsRepository, userCommonsRepository, ctx);
             
             } else{
-                //ctx.log("Game is not currently in progress, cow health will not be updated for this commons.");
-                runUpdateJobInCommons(commons, commonsPlus, commonsPlusBuilderService, commonsRepository, userCommonsRepository, ctx);
+                ctx.log("Game is not currently in progress, cow health will not be updated for this commons.");
             }
         }
 
@@ -80,10 +81,7 @@ public class UpdateCowHealthJob implements JobContextConsumer {
                 ctx.log("No users in this commons, skipping");
                 return;
             }
-            // if(!commons.gameInProgress()) {
-            //     ctx.log("Commons test commons is not currently in progress, cows will not be milked in this commons.");
-                
-            // }
+            
 
             int carryingCapacity = commonsPlus.getEffectiveCapacity();
             Iterable<UserCommons> allUserCommons = userCommonsRepository.findByCommonsId(commons.getId());

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
@@ -38,9 +38,13 @@ public class UpdateCowHealthJob implements JobContextConsumer {
 
 
             Commons commons = commonsPlus.getCommons();
+            if(!commons.gameInProgress()){
+                ctx.log("Game is not currently in progress, cow health will not be updated for this commons.");
             
-            runUpdateJobInCommons(commons, commonsPlus, commonsPlusBuilderService, commonsRepository, userCommonsRepository, ctx);
-            
+            } else{
+                //ctx.log("Game is not currently in progress, cow health will not be updated for this commons.");
+                runUpdateJobInCommons(commons, commonsPlus, commonsPlusBuilderService, commonsRepository, userCommonsRepository, ctx);
+            }
         }
 
         ctx.log("Cow health has been updated!");
@@ -76,6 +80,10 @@ public class UpdateCowHealthJob implements JobContextConsumer {
                 ctx.log("No users in this commons, skipping");
                 return;
             }
+            // if(!commons.gameInProgress()) {
+            //     ctx.log("Commons test commons is not currently in progress, cows will not be milked in this commons.");
+                
+            // }
 
             int carryingCapacity = commonsPlus.getEffectiveCapacity();
             Iterable<UserCommons> allUserCommons = userCommonsRepository.findByCommonsId(commons.getId());

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
@@ -39,13 +39,8 @@ public class UpdateCowHealthJob implements JobContextConsumer {
 
             Commons commons = commonsPlus.getCommons();
             //ctx.log(String.format("commoms.startDate=%s commons.lastDay=%s", commons.getStartingDate().toString(),commons.getLastDay().toString()));
-            if(commons.gameInProgress()){
-                
-                runUpdateJobInCommons(commons, commonsPlus, commonsPlusBuilderService, commonsRepository, userCommonsRepository, ctx);
+            runUpdateJobInCommons(commons, commonsPlus, commonsPlusBuilderService, commonsRepository, userCommonsRepository, ctx);
             
-            } else{
-                ctx.log("Game is not currently in progress, cow health will not be updated for this commons.");
-            }
         }
 
         ctx.log("Cow health has been updated!");

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
@@ -1,5 +1,4 @@
 package edu.ucsb.cs156.happiercows.jobs;
-
 import edu.ucsb.cs156.happiercows.entities.Commons;
 import edu.ucsb.cs156.happiercows.entities.CommonsPlus;
 import edu.ucsb.cs156.happiercows.entities.User;
@@ -29,24 +28,18 @@ public class UpdateCowHealthJob implements JobContextConsumer {
     @Override
     public void accept(JobContext ctx) throws Exception {
         ctx.log("Updating cow health...");
-
-
         Iterable<Commons> allCommons = commonsRepository.findAll();
         Iterable<CommonsPlus> allCommonsPlus = commonsPlusBuilderService.convertToCommonsPlus(allCommons);
 
         for (CommonsPlus commonsPlus : allCommonsPlus) {
-
-
             Commons commons = commonsPlus.getCommons();
             //ctx.log(String.format("commoms.startDate=%s commons.lastDay=%s", commons.getStartingDate().toString(),commons.getLastDay().toString()));
             runUpdateJobInCommons(commons, commonsPlus, commonsPlusBuilderService, commonsRepository, userCommonsRepository, ctx);
             
         }
-
         ctx.log("Cow health has been updated!");
     }
 
-    // exposed for testing
     public static double calculateNewCowHealthUsingStrategy(
             CowHealthUpdateStrategy strategy,
             CommonsPlus commonsPlus,
@@ -77,7 +70,6 @@ public class UpdateCowHealthJob implements JobContextConsumer {
                 return;
             }
             
-
             int carryingCapacity = commonsPlus.getEffectiveCapacity();
             Iterable<UserCommons> allUserCommons = userCommonsRepository.findByCommonsId(commons.getId());
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
@@ -33,7 +33,6 @@ public class UpdateCowHealthJob implements JobContextConsumer {
 
         for (CommonsPlus commonsPlus : allCommonsPlus) {
             Commons commons = commonsPlus.getCommons();
-            //ctx.log(String.format("commoms.startDate=%s commons.lastDay=%s", commons.getStartingDate().toString(),commons.getLastDay().toString()));
             runUpdateJobInCommons(commons, commonsPlus, commonsPlusBuilderService, commonsRepository, userCommonsRepository, ctx);
             
         }

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
@@ -90,6 +90,5 @@ public class UpdateCowHealthJob implements JobContextConsumer {
                 ctx.log(" old cow health: " + oldHealth + ", new cow health: " + userCommons.getCowHealth());
                 userCommonsRepository.save(userCommons);
             }
-
     }
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobTests.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.LocalDateTime;
 import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
@@ -33,8 +34,9 @@ public class InstructorReportJobTests {
     void test_log_output() throws Exception {
 
         // Arrange
-
-        Commons commons= Commons.builder().id(17L).name("CS156").build();
+         LocalDateTime startDate = LocalDateTime.parse("2021-03-05T15:50:10");
+        LocalDateTime endDate = LocalDateTime.parse("3000-04-08T15:50:10");
+        Commons commons= Commons.builder().id(17L).name("CS156").startingDate(startDate).lastDay(endDate).build();
         Report report = Report.builder().id(17L).build();
         
         Job jobStarted = Job.builder().build();
@@ -60,4 +62,71 @@ public class InstructorReportJobTests {
 
         assertEquals(expected, jobStarted.getLog());
     }
+
+    @Test
+    void before_start_date() throws Exception {
+
+        // Arrange
+        LocalDateTime startDate = LocalDateTime.parse("3000-03-05T15:50:10");
+        LocalDateTime endDate = LocalDateTime.parse("3000-04-08T15:50:10");
+        Commons commons= Commons.builder().id(17L).name("CS156").startingDate(startDate).lastDay(endDate).build();
+        Report report = Report.builder().id(17L).build();
+        
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+      
+        when(commonsRepository.findAll()).thenReturn(Arrays.asList(commons));      
+        when(reportService.createReport(17L)).thenReturn(report);
+
+        // Act
+        InstructorReportJob instructorReportJob = new InstructorReportJob(reportService, commonsRepository);
+        instructorReportJob.accept(ctx);
+
+        // Assert
+
+        // verify(commonsRepository).findAll();
+        // verify(reportService).createReport(17L);
+        
+        String expected = """
+            Starting instructor report...
+            Game is not currently in progress, report will not be filed in this common.
+            Instructor report done!""";
+
+        assertEquals(expected, jobStarted.getLog());
+    }
+
+
+     @Test
+    void after_end_date() throws Exception {
+
+        // Arrange
+        LocalDateTime startDate = LocalDateTime.parse("2020-03-05T15:50:10");
+        LocalDateTime endDate = LocalDateTime.parse("2020-04-08T15:50:10");
+        Commons commons= Commons.builder().id(17L).name("CS156").startingDate(startDate).lastDay(endDate).build();
+        Report report = Report.builder().id(17L).build();
+        
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+      
+        when(commonsRepository.findAll()).thenReturn(Arrays.asList(commons));      
+        when(reportService.createReport(17L)).thenReturn(report);
+
+        // Act
+        InstructorReportJob instructorReportJob = new InstructorReportJob(reportService, commonsRepository);
+        instructorReportJob.accept(ctx);
+
+        // Assert
+
+        // verify(commonsRepository).findAll();
+        // verify(reportService).createReport(17L);
+        
+        String expected = """
+            Starting instructor report...
+            Game is not currently in progress, report will not be filed in this common.
+            Instructor report done!""";
+
+        assertEquals(expected, jobStarted.getLog());
+    }
+
+    
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobTests.java
@@ -86,7 +86,6 @@ public class InstructorReportJobTests {
      @Test
     void after_end_date() throws Exception {
 
-        // Arrange
         LocalDateTime startDate = LocalDateTime.parse("2020-03-05T15:50:10");
         LocalDateTime endDate = LocalDateTime.parse("2020-04-08T15:50:10");
         Commons commons= Commons.builder().id(17L).name("CS156").startingDate(startDate).lastDay(endDate).build();

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobTests.java
@@ -1,12 +1,9 @@
 package edu.ucsb.cs156.happiercows.jobs;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
 import java.time.LocalDateTime;
 import java.util.Arrays;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -33,8 +30,7 @@ public class InstructorReportJobTests {
     @Test
     void test_log_output() throws Exception {
 
-        // Arrange
-         LocalDateTime startDate = LocalDateTime.parse("2021-03-05T15:50:10");
+        LocalDateTime startDate = LocalDateTime.parse("2021-03-05T15:50:10");
         LocalDateTime endDate = LocalDateTime.parse("3000-04-08T15:50:10");
         Commons commons= Commons.builder().id(17L).name("CS156").startingDate(startDate).lastDay(endDate).build();
         Report report = Report.builder().id(17L).build();
@@ -45,11 +41,8 @@ public class InstructorReportJobTests {
         when(commonsRepository.findAll()).thenReturn(Arrays.asList(commons));      
         when(reportService.createReport(17L)).thenReturn(report);
 
-        // Act
         InstructorReportJob instructorReportJob = new InstructorReportJob(reportService, commonsRepository);
         instructorReportJob.accept(ctx);
-
-        // Assert
 
         verify(commonsRepository).findAll();
         verify(reportService).createReport(17L);
@@ -78,15 +71,10 @@ public class InstructorReportJobTests {
         when(commonsRepository.findAll()).thenReturn(Arrays.asList(commons));      
         when(reportService.createReport(17L)).thenReturn(report);
 
-        // Act
+       
         InstructorReportJob instructorReportJob = new InstructorReportJob(reportService, commonsRepository);
         instructorReportJob.accept(ctx);
 
-        // Assert
-
-        // verify(commonsRepository).findAll();
-        // verify(reportService).createReport(17L);
-        
         String expected = """
             Starting instructor report...
             Game is not currently in progress, report will not be filed in this common.
@@ -94,7 +82,6 @@ public class InstructorReportJobTests {
 
         assertEquals(expected, jobStarted.getLog());
     }
-
 
      @Test
     void after_end_date() throws Exception {
@@ -111,15 +98,10 @@ public class InstructorReportJobTests {
         when(commonsRepository.findAll()).thenReturn(Arrays.asList(commons));      
         when(reportService.createReport(17L)).thenReturn(report);
 
-        // Act
+        
         InstructorReportJob instructorReportJob = new InstructorReportJob(reportService, commonsRepository);
         instructorReportJob.accept(ctx);
 
-        // Assert
-
-        // verify(commonsRepository).findAll();
-        // verify(reportService).createReport(17L);
-        
         String expected = """
             Starting instructor report...
             Game is not currently in progress, report will not be filed in this common.
@@ -128,5 +110,4 @@ public class InstructorReportJobTests {
         assertEquals(expected, jobStarted.getLog());
     }
 
-    
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJobTests.java
@@ -1,5 +1,4 @@
 package edu.ucsb.cs156.happiercows.jobs;
-
 import edu.ucsb.cs156.happiercows.entities.Commons;
 import edu.ucsb.cs156.happiercows.entities.User;
 import edu.ucsb.cs156.happiercows.entities.UserCommons;
@@ -57,7 +56,6 @@ public class MilkTheCowsJobTests {
             .degradationRate(0.01)
             .build();
 
-
     @Test
     void test_log_output_no_commons() throws Exception {
 
@@ -66,13 +64,10 @@ public class MilkTheCowsJobTests {
         Job jobStarted = Job.builder().build();
         JobContext ctx = new JobContext(null, jobStarted);
 
-        // Act
         MilkTheCowsJob milkTheCowsJob = new MilkTheCowsJob(commonsRepository, userCommonsRepository,
                 userRepository, profitRepository);
 
         milkTheCowsJob.accept(ctx);
-
-        // Assert
 
         String expected = """
                 Starting to milk the cows
@@ -84,7 +79,6 @@ public class MilkTheCowsJobTests {
     @Test
     void test_log_output_with_commons_and_user_commons() throws Exception {
 
-        // Arrange
         Job jobStarted = Job.builder().build();
         JobContext ctx = new JobContext(null, jobStarted);
 
@@ -159,7 +153,6 @@ public class MilkTheCowsJobTests {
         MilkTheCowsJob.milkCows(ctx, testCommons, origUserCommons, profitRepository, userCommonsRepository);
 
         // Assert
-
         String expected = """
                 User: Chris Gaucho, numCows: 1, cowHealth: 10.0, totalWealth: $300.00
                 Profit for user: Chris Gaucho is: $0.20, newWealth: $300.20""";
@@ -206,12 +199,10 @@ public class MilkTheCowsJobTests {
         when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
         when(userRepository.findById(1L)).thenReturn(Optional.of(user));
 
-        // Act
         MilkTheCowsJob MilkTheCowsJob = new MilkTheCowsJob(commonsRepository, userCommonsRepository,
                 userRepository, profitRepository);
         MilkTheCowsJob.accept(ctx);
 
-        // Assert
 
         String expected = """
                 Starting to milk the cows
@@ -221,11 +212,9 @@ public class MilkTheCowsJobTests {
         assertEquals(expected, jobStarted.getLog());
     }
 
-    
     @Test
     void test_cannot_milk_cows_when_after_end_date() throws Exception {
-            
-        // Arrange
+
         Job jobStarted = Job.builder().build();
         JobContext ctx = new JobContext(null, jobStarted);
         LocalDateTime startDate = LocalDateTime.parse("2022-03-05T15:50:10");
@@ -260,12 +249,9 @@ public class MilkTheCowsJobTests {
         when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
         when(userRepository.findById(1L)).thenReturn(Optional.of(user));
 
-        // Act
         MilkTheCowsJob MilkTheCowsJob = new MilkTheCowsJob(commonsRepository, userCommonsRepository,
                 userRepository, profitRepository);
         MilkTheCowsJob.accept(ctx);
-
-        // Assert
 
         String expected = """
                 Starting to milk the cows

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobTests.java
@@ -29,6 +29,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
@@ -389,143 +390,7 @@ public class UpdateCowHealthJobTests {
                                 thrown.getMessage());
         }
 
-        @Test
-        void test_updating_if_game_start_has_not_passed() throws Exception {
-
-                // Arrange
-                Job jobStarted = Job.builder().build();
-                JobContext ctx = new JobContext(null, jobStarted);
-                LocalDateTime startDate = LocalDateTime.parse("3000-03-05T15:50:10");
-                LocalDateTime endDate = LocalDateTime.parse("3000-04-08T15:50:10");
-
-                UserCommons origUserCommons = UserCommons
-                                .builder()
-                                .user(user)
-                                .commons(commons)
-                                .totalWealth(300)
-                                .numOfCows(5)
-                                .cowHealth(-1.0)
-                                .cowDeaths(0)
-                                .build();
-
-                Commons testCommons = Commons
-                                .builder()
-                                .name("test commons")
-                                .cowPrice(1)
-                                .milkPrice(2)
-                                .startingBalance(300)
-                                .startingDate(startDate)
-                                .lastDay(endDate)
-                                .capacityPerUser(0)
-                                .carryingCapacity(100)
-                                .degradationRate(1)
-                                .belowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Noop)
-                                .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Noop)
-                                .build();
-
-                UserCommons newUserCommons = UserCommons
-                                .builder()
-                                .user(user)
-                                .commons(commons)
-                                .totalWealth(300 -testCommons.getCowPrice())
-                                .numOfCows(5)
-                                .cowHealth(-1.0)
-                                .cowDeaths(0)
-                                .build();
-
-                Commons commonsTemp[] = { testCommons };
-                UserCommons userCommonsTemp[] = { origUserCommons };
-                when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
-                when(userCommonsRepository.findByCommonsId(testCommons.getId()))
-                                .thenReturn(Arrays.asList(userCommonsTemp));
-                when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(101)));
-                when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-
-                // Act
-                UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
-                         userRepository, commonsPlusBuilderService);
-
-                updateCowHealthJob.accept(ctx);
-
-                // Assert
-
-                String expected = """
-                               Updating cow health...
-                               Game is not currently in progress, cow health will not be updated for this commons.
-                               Cow health has been updated!""";
-
-                assertEquals(expected, jobStarted.getLog());
-                assertEquals(origUserCommons.getCowHealth(), newUserCommons.getCowHealth());
-        }
-
-        // @Test
-        // void test_updating_if_game_end_has_passed() throws Exception {
-
-        //         // Arrange
-        //         Job jobStarted = Job.builder().build();
-        //         JobContext ctx = new JobContext(null, jobStarted);
-        //         LocalDateTime startDate = LocalDateTime.parse("2020-03-05T15:50:10");
-        //         LocalDateTime endDate = LocalDateTime.parse("2020-04-08T15:50:10");
-
-        //         UserCommons origUserCommons = UserCommons
-        //                         .builder()
-        //                         .user(user)
-        //                         .commons(commons)
-        //                         .totalWealth(300)
-        //                         .numOfCows(5)
-        //                         .cowHealth(-1.0)
-        //                         .cowDeaths(0)
-        //                         .build();
-
-        //         Commons testCommons = Commons
-        //                         .builder()
-        //                         .name("test commons")
-        //                         .cowPrice(1)
-        //                         .milkPrice(2)
-        //                         .startingBalance(300)
-        //                         .startingDate(startDate)
-        //                         .lastDay(endDate)
-        //                         .capacityPerUser(0)
-        //                         .carryingCapacity(100)
-        //                         .degradationRate(1)
-        //                         .belowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Noop)
-        //                         .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Noop)
-        //                         .build();
-
-        //         UserCommons newUserCommons = UserCommons
-        //                         .builder()
-        //                         .user(user)
-        //                         .commons(commons)
-        //                         .totalWealth(300 -testCommons.getCowPrice())
-        //                         .numOfCows(5)
-        //                         .cowHealth(-1.0)
-        //                         .cowDeaths(0)
-        //                         .build();
-
-        //         Commons commonsTemp[] = { testCommons };
-        //         UserCommons userCommonsTemp[] = { origUserCommons };
-        //         when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
-        //         when(userCommonsRepository.findByCommonsId(testCommons.getId()))
-        //                         .thenReturn(Arrays.asList(userCommonsTemp));
-        //         when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(101)));
-        //         when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-
-        //         // Act
-        //         UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
-        //                  userRepository, commonsPlusBuilderService);
-
-        //         updateCowHealthJob.accept(ctx);
-
-        //         // Assert
-
-        //         String expected = """
-        //                        Updating cow health...
-        //                        Game is not currently in progress, cow health will not be updated for this commons.
-        //                        Cow health has been updated!""";
-
-        //         assertEquals(expected, jobStarted.getLog());
-        //         assertEquals(origUserCommons.getCowHealth(), newUserCommons.getCowHealth());
-        // }
+     
 
        
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobTests.java
@@ -18,12 +18,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.Arrays;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -69,8 +67,6 @@ public class UpdateCowHealthJobTests {
                         .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Noop)
                         .build();
 
-
-
         private final UserCommons userCommons = UserCommons
                         .builder()
                         .user(user)
@@ -79,8 +75,6 @@ public class UpdateCowHealthJobTests {
                         .numOfCows(1)
                         .cowHealth(10.0)
                         .build();
-
-
 
         private final Job job = Job.builder().build();
         private final JobContext ctx = new JobContext(null, job);
@@ -162,7 +156,6 @@ public class UpdateCowHealthJobTests {
                 runUpdateCowHealthJob();
 
                 assertEquals(expectedNewHealth, userCommons.getCowHealth());
-
                 String expected = """
                                 Updating cow health...
                                 Commons test commons, degradationRate: 1.0, effectiveCapacity: 100
@@ -296,7 +289,6 @@ public class UpdateCowHealthJobTests {
                                 .cowDeaths(0)
                                 .build();
                 commons.setBelowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear);
-
                 CommonsPlus commonsPlus = CommonsPlus.builder().commons(commons).totalCows(5).totalUsers(1).build();
 
                 List<CommonsPlus> commonsPlusList = List.of(commonsPlus);
@@ -310,9 +302,7 @@ public class UpdateCowHealthJobTests {
                 when(commonsRepository.getNumCows(commons.getId())).thenReturn(Optional.of(99));
                 when(userRepository.findById(1L)).thenReturn(Optional.of(user));
                 when(commonsRepository.getNumUsers(commons.getId())).thenReturn(Optional.of(1));
-
                 runUpdateCowHealthJob();
-
                 String expected = """
                                 Updating cow health...
                                 Commons test commons, degradationRate: 1.0, effectiveCapacity: 100
@@ -390,7 +380,4 @@ public class UpdateCowHealthJobTests {
                                 thrown.getMessage());
         }
 
-     
-
-       
 }


### PR DESCRIPTION
## Overview
This pull request
- completes issue 35, " instructor requests a job be run on a specific commons, it should run even if the game is not in progress."
- works on issue 34, Add logic to the backends of various jobs that operate on all commons (MilkTheCows, UpdateCowHealth, InstructorReports) where it iterates over the commons. Skip over commons where gameInProgress() returns false
NOTE: this PR will complete the implementation of adding gameInProgress() logic to MilkTheCowsJob.java and InstructorReportsJob.java, but NOT UpdateCowHealthJob.java. Professor Conrad stated this element could be left for W24

Deployed on Dokku:
https://happycows-madisonlong1.dokku-03.cs.ucsb.edu/

## Screenshots (Optional)
For a game that has not started yet
![image](https://github.com/ucsb-cs156-f23/proj-happycows-f23-5pm-3/assets/111256350/934aa264-af02-4aeb-acb4-35827ea35316)

Now, instructorReports and MilkTheCows will not run if the game is not currently in progress, not as per the issue description, this was a **backend** change and is **not** currently visable from the frontend
![image](https://github.com/ucsb-cs156-f23/proj-happycows-f23-5pm-3/assets/111256350/225830de-b3eb-453d-9c70-3a6f9fd8195c)





## Validation (Optional)
<!--Steps that someone else could take to make sure everything is working-->
1. Download this branch.
2. Run the project.
3. Go to this page.
4. Test this function.

## Tests
<!--Add any additional tests or required tests-->
- [x] Backend Unit tests (`mvn test`) pass
- [x] Backend Test coverage (`mvn test jacoco:report`) 100%
- [x] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #34
Closes #35